### PR TITLE
Consider `access` when comparing categories

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/CategoryImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/CategoryImpl.java
@@ -91,7 +91,8 @@ public class CategoryImpl extends ResourceImpl implements Category {
     Category category = (Category) o;
     return id == category.getId() && videoId.equals(category.getVideoId()) && scaleId.equals(category.getScaleId())
             && name.equals(category.getName()) && description.equals(category.getDescription())
-            && settings.equals(category.getSettings()) && getTags().equals(category.getTags());
+            && getAccess() == category.getAccess() && settings.equals(category.getSettings())
+            && getTags().equals(category.getTags());
   }
 
   @Override


### PR DESCRIPTION
This becomes a problem once merge opencast/annotation-tool#407 and opencast/annotation-tool#414 together. One of the symptoms is/will be opencast/annotation-tool#450.